### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Midihub Documentation
 
-If your are looking for Midihub documentation, head straight to the [docs page](https://blokas.io/midihub/docs/)!
+If you are looking for Midihub documentation, head straight to the [docs page](https://blokas.io/midihub/docs/)!
 
 
 # Contribution Guide


### PR DESCRIPTION
## Summary
- fix typo in documentation intro

## Testing
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e92303904832dbff9400fad7bd926