### PR TITLE
Fix typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Midihub Documentation
 
-If your are looking for Midihub documentation, head straight to the [docs page](https://blokas.io/midihub/docs/)!
+If you are looking for Midihub documentation, head straight to the [docs page](https://blokas.io/midihub/docs/)!
 
 
 # Contribution Guide
 
-Everyone can contribute through GitHub UI or cloning this repo `git clone --recursive https://github.com/BlokasLabs/midihub-docs.git`.
+Everyone can contribute through GitHub UI or by cloning this repo `git clone --recursive https://github.com/BlokasLabs/midihub-docs.git`.
 
 
 # Serving Documentation via `mkdocs`

--- a/docs/arpeggiator.md
+++ b/docs/arpeggiator.md
@@ -2,9 +2,9 @@
 
 ![arpeggiator](https://blokas.io/images/midihub/pipes/arp.svg)
 
-A modifier pipe that produces arpeggios using the held down notes at the given rate, using the velocity of the last note held down or aftertouch.
+A modifier pipe that produces arpeggios using the held-down notes at the given rate, using the velocity of the last note held down or aftertouch.
 Swing and accent can be applied to the produced notes. The notes produced are quantized to the tempo, so **MIDI Clock messages must
-reach this pipe** for it to be able to do its work. The notes only get produced on quantization grid.
+reach this pipe** for it to be able to do its work. The notes are produced only on the quantization grid.
 
 The arpeggio sequences will get repeated on the next octave, according to the Octave Range parameter.
 
@@ -21,9 +21,9 @@ Multiple variations of note sequences can be selected:
 |  Up and Down Incl.   | Go up and down, repeating the high note once. |
 |  Down and Up Incl.   | Go down and up, repeating the low note once. |
 |  Low Up              | Repeat the low note every 2nd time while progressing up. |
-|  Low Up and Down     | Repeat the low not every 2nd time while progressing up, then down. 4 or more notes needed. |
+|  Low Up and Down     | Repeat the low note every 2nd time while progressing up, then down. 4 or more notes needed. |
 |  High Up             | Repeat the high note every 2nd time while progressing up. |
-|  High Up and Down    | Repeat the high not every 2nd time while progressing up, then down. 4 or more notes needed. |
+|  High Up and Down    | Repeat the high note every 2nd time while progressing up, then down. 4 or more notes needed. |
 |  Chords              | Play all the notes at once, for use with Octave parameter. |
 |  Random              | Play random notes based on the held down keys and octave range. |
 |  Entirely Up then Down | Similar to Up and Down, except it goes to the end of the Octave Range before going back down. |

--- a/docs/cc-lfo.md
+++ b/docs/cc-lfo.md
@@ -11,7 +11,7 @@ If it is placed as a Modifier, it can be synchronized to the beat,
 as well as it can apply modulation to previous CC LFO pipes in the pipeline,
 and/or to the incoming CC value from the input.
 
-See the preview at the bottom of the the Properties panel to visualize how the LFO waveform looks like.
+See the preview at the bottom of the Properties panel to visualize how the LFO waveform looks.
 
 | Parameter              | Description                    |
 | ---------------------- | ------------------------------ |
@@ -25,7 +25,7 @@ See the preview at the bottom of the the Properties panel to visualize how the L
 | Waveform               | The waveform of the LFO. For Sample & Hold waveform description, see below. |
 | Duty Cycle             | The duty cycle of the PWM wave. Not applicable to other waveforms. |
 | Output Enabled         | Whether the output is actually enabled. Output may be disabled while keeping the LFO clock still ticking. |
-| Mode                   | **Free running**: waveform is generated freely.<br/>**Active Mod.**: LFO is actively modulating (offsetting) the incoming CC value of the same id, generating new values even if incoming CC value is not changing.<br/>**Passive Mod.**: LFO is passively modulating (offseting) the incoming CC value of the same id, only on receiving the actual CC value. |
+| Mode                   | **Free running**: waveform is generated freely.<br/>**Active Mod.**: LFO is actively modulating (offsetting) the incoming CC value of the same id, generating new values even if the incoming CC value is not changing.<br/>**Passive Mod.**: LFO is passively modulating (offsetting) the incoming CC value of the same id, only on receiving the actual CC value. |
 | Retrigger              | Controls retriggering behavior - LFO waveform can be retriggered on individual notes or on chords. |
 | Sync to BPM            | (Only as Modifier) Whether to sync to the incoming BPM clock. |
 | Retrigger on SysCommon | (Only as Modifier) Whether to retrigger on system common messages such as 'start', 'continue', 'song position pointer'. |
@@ -41,7 +41,7 @@ If it is placed as a Generator, the S&H LFO uses Noise as a sampling input.
 If it is placed as a Modifier, however, the S&H LFO needs a CC input in all three of its modes (including Free Running mode).
 Here it uses the last received CC value for sampling: this CC input might be direct or modified from an external source, or from another Midihub LFO.
 
-For example, a tempo-synced Free Running S&H LFO might use a Noise LFO to sample and hold random values every bar (at points set by Phase, Duty Cycle and Rate)
+For example, a tempo-synced Free Running S&H LFO might use a Noise LFO to sample and hold random values every bar (at points set by Phase, Duty Cycle and Rate). 
 
 When a S&H LFO is in Active/Passive Mod Mode, Depth represents how much the output value's displacement from 64 should be 'amplified'. For example, 68 -> 68 at 0%, 68 -> 70 at 50%, 68 -> 72 at 100%.
 

--- a/docs/cc-range-filter.md
+++ b/docs/cc-range-filter.md
@@ -7,7 +7,7 @@ A modifier pipe that can discard or keep MIDI CC events in the desired ranges.
 Both ends of the ranges are inclusive.
 
 A single pipe can store up to 9 argument values which are shared for the interval ranges, as well as
-single values. In case of running out of space, a tooltip regarding it will get shown.
+single values. If you run out of space, a tooltip will be shown.
 If you'd like to define more ranges, just put multiple Range Filter pipes in series.
 
 ## Example Range

--- a/docs/channel-range-filter.md
+++ b/docs/channel-range-filter.md
@@ -15,7 +15,7 @@ Filter out first 4 channels, channel 6 and the 8 last channels:
 | Parameter              | Description                    |
 | ---------------------- | ------------------------------ |
 | Bypass                 | Whether processing is enabled. |
-| Drop in range          | Whether to drop messages within any of the ranges. Disabling this would inverse the operation and make it keep messages within the ranges. |
+| Drop in range          | Whether to drop messages within any of the ranges. Disabling this inverts the operation and makes it keep messages within the ranges. |
 | Ranges                 | A list of interval ranges and single values. See above for examples. |
 
 <span class="blokas-web-hide">

--- a/docs/delay.md
+++ b/docs/delay.md
@@ -21,9 +21,9 @@ held down notes.
 | Bypass                 | Whether processing is enabled.     |
 | Delay Time             | The amount of time to delay incoming notes. It can be synced to the incoming tempo, or specified in milliseconds. Can be set to 0 to produce note events immediately. In that case, Infinite parameter is ignored. |
 | Note Length            | The note length to use for every note, if Fixed Length is enabled.  |
-| Repetitions            | The number of times to repeat a note, can be overriden by Infinite parameter.  |
+| Repetitions            | The number of times to repeat a note, can be overridden by the Infinite parameter.  |
 | Feedback               | The amount of feedback to apply to the velocity of delayed notes. |
-| Dry/Wet                | The velocity ratio betwen the original note and the delayed notes:<br/><br/>**0%**: full velocity of original note, 0 velocity of delayed notes,<br/>**50%**: full velocity of both parts,<br/>**100%**: 0 velocity of original notes, full velocity of delayed notes. |
+| Dry/Wet                | The velocity ratio between the original note and the delayed notes:<br/><br/>**0%**: full velocity of original note, 0 velocity of delayed notes,<br/>**50%**: full velocity of both parts,<br/>**100%**: 0 velocity of original notes, full velocity of delayed notes. |
 | Infinite               | If on, the notes will be repeated infinite number of times, unless its velocity reaches 0 first. |
 | Sync                   | Switch between synced and freerunning modes. |
 | Fixed Length           | Whether to use variable lengths of notes as they were played, or the same fixed length for every note, as set by Note Length parameter. |

--- a/docs/device.md
+++ b/docs/device.md
@@ -4,7 +4,7 @@
 
 Midihub is the backbone of your MIDI hardware interconnectivity. It has MIDI DIN-5 input and output ports, 4 of each, as well as a USB port for power supply
 and/or communicating with the PC and its software. All MIDI data flows through the customizable MIDI Processing Pipelines within the device with extremely low
-latency and without involving any processing on the PC. It enables expanding the capabilities of your setup and makes interop between MIDI hardware easy.
+latency and without involving any processing on the PC. It enables expanding the capabilities of your setup and makes interoperability between MIDI hardware easy.
 
 ## Input / Output
 
@@ -16,8 +16,8 @@ are defined by the OS that is running on your PC.
 
 See [The USB MIDI Port Mapping](usb-midi-port-mapping.md) for more details.
 
-MIDI controllers with only USB output can't be connected directly to Midihub, however, they can still be used with Midihub if both are connected via a USB host such
-as your PC or something like Raspberry Pi, the host then can forward the MIDI data coming from a USB controller to one (or more) Midihub's USB ports. The utilities
+MIDI controllers with only USB output can't be connected directly to Midihub; however, they can still be used with Midihub if both are connected via a USB host,
+such as your PC or a Raspberry Pi. The host can then forward the MIDI data coming from a USB controller to one (or more) of Midihub's USB ports. The utilities
 to achieve this vary with the OS, but to list a few, there's 'aconnect' for Linux, 'MIDI Patchbay' on Mac, 'MIDI-OX' on Windows, and most DAWs provide the functionality
 to forward MIDI data between connected MIDI ports.
 
@@ -48,7 +48,7 @@ The Button can be configured to do one of the following actions when held down f
 
 ### External Preset Change
 
-You may make a particular Midihub's port to listen for Program Change messages on a particular channel. PC0 - PC7 messages switch between presets 1 - 8.
+You may configure a particular Midihub port to listen for Program Change messages on a particular channel. PC0 - PC7 messages switch between presets 1 - 8.
 
 ### Initial Preset
 
@@ -56,7 +56,7 @@ Depending on the Initial Preset setting, upon powering on, Midihub either loads 
 
 ## Technical Specification
 
-| MIDI Paremeters | Value | Other Parameters | Value
+| MIDI Parameters | Value | Other Parameters | Value
 |----|----|----|----|
 | Input/Output Connectors | 8 x DIN-5 Female Sockets & USB-B Port | Enclosure | Powder-Coated 1mm Steel |
 | MIDI Loopback Latency | Less than 1.5ms | Power | Bus-Powered - Computer or 5V USB Power Supply |

--- a/docs/equalizer.md
+++ b/docs/equalizer.md
@@ -2,7 +2,7 @@
 
 ![equalizer](https://blokas.io/images/midihub/pipes/equalizer.svg)
 
-A modifier pipe that applies a 3 band Eq curve on message values indicated by the Kind parameter.
+A modifier pipe that applies a 3-band EQ curve to message values indicated by the Kind parameter.
 
 The 3 bands are located at these positions:
 
@@ -13,7 +13,7 @@ The 3 bands are located at these positions:
 | Middle C4 std. | C1  | C4     | C7   |
 | Middle C5 std. | C2  | C5     | C8   |
 
-See the preview at the bottom of the the Properties panel to see how the curve looks like.
+See the preview at the bottom of the Properties panel to see how the curve looks.
 
 | Parameter              | Description                                              |
 | ---------------------- | -------------------------------------------------------- |

--- a/docs/insert-preview.md
+++ b/docs/insert-preview.md
@@ -1,6 +1,6 @@
 # Insert Preview
 
-The Preview window shows what is about to get imported. At this stage, you may want to:
+The Preview window shows what is about to be imported. At this stage, you may want to:
 
 * **Change all input or output ports** as needed for your setup. (Can be changed in bulk via the right click menu)
 
@@ -12,4 +12,4 @@ The Preview window shows what is about to get imported. At this stage, you may w
 
 Radio button is available for selecting whether to show the port names of the incoming preset or the main preset.
 
-Virtual input or output pipes that use the same port letter in the main preset are indicated by a purple rectangle in their corners. This gives you a chance to adjust their source/destination properties as necessary prior to inserting into the main preset.
+Virtual input or output pipes that use the same port letter in the main preset are indicated by a purple rectangle in their corners. This gives you a chance to adjust their source or destination properties as necessary prior to inserting into the main preset.

--- a/docs/inserting-from-patchstorage.md
+++ b/docs/inserting-from-patchstorage.md
@@ -1,12 +1,13 @@
 # Inserting from Patchstorage
 
-User uploaded pipelines can be browsed for and imported using the Patchstorage pane. You may toggle its visibility
-using View->Patchstorage menu option, or pressing F5 on the keyboard.
+User-uploaded pipelines can be browsed and imported using the Patchstorage pane. You may toggle its visibility
+using the View->Patchstorage menu option, or by pressing F5 on the keyboard.
 
 You may filter results using the search bar and you may specify how you'd like the list sorted.
 
-To import a patch from Patchstorage, double click on the list entry of interest, or use the 'Enter' / 'Return' key on keyboard to append the.
-Patch at the bottom of the current preset. You may also Drag and Drop the preset from the list straight into the current preset to insert it
-in the dropped location. These actions will open the [Insert Preview](insert-preview.md). The preview will show how the pipelines will look like,
+To import a patch from Patchstorage, double-click the list entry of interest, or use the 'Enter' / 'Return' key on the keyboard to append the patch
+at the bottom of the current preset. You may also drag and drop the preset from the list straight into the current preset to insert it
+in the dropped location. These actions will open the [Insert Preview](insert-preview.md). The preview will show how the pipelines will look,
 as well as the full description of the patch as available on Patchstorage. The pipes can be modified before importing, you may want to do so to set
 up the input and output ports according to your hardware setup.
+

--- a/docs/midi-monitor.md
+++ b/docs/midi-monitor.md
@@ -6,15 +6,15 @@ The MIDI Monitor shows the MIDI events that are being processed by the currently
 Filters for incoming and outgoing data can be set up to hide irrelevant events.
 The events may be displayed in their raw hex form, or decoded into a readable form.
 
-A BPM field in the monitor header provides the BPM estimate based on the timing of the recent Clock messages, even if they're filtered out from display.
+A BPM field in the monitor header provides a BPM estimate based on the timing of the recent Clock messages, even if they're filtered out from display.
 
-If the monitor is scrolled to the very bottom, it will stay at bottom and follow the new events.
+If the monitor is scrolled to the very bottom, it will stay at the bottom and follow the new events.
 
 Each event consists of the following fields:
 
 | Field     | Description                   |
 | --------  | ----------------------------- |
 | Timestamp | It is recorded when the event is being processed, based on the internal clock of Midihub, and is in millisecond accuracy. |
-| Type      | They type of the event. It can be one of:<br/><br/>**Event**: A regular MIDI event.<br/>**Timed**: An output was generated based on time.<br/>**Mapping**: A mapped parameter change caused an event to be generated.<br/>**Param Chg**: The pipe parameter change caused an event to be generated.<br/>**Overflow**: If there's more events occurring than the monitor can read, an overflow is recorded, and some monitor data can get dropped. |
+| Type      | The type of the event. It can be one of:<br/><br/>**Event**: A regular MIDI event.<br/>**Timed**: An output was generated based on time.<br/>**Mapping**: A mapped parameter change caused an event to be generated.<br/>**Param Chg**: The pipe parameter change caused an event to be generated.<br/>**Overflow**: If there's more events occurring than the monitor can read, an overflow is recorded, and some monitor data can get dropped. |
 | Incoming  | The incoming event data. |
-| Outgoing  | The outgoing processed data. If the field is empty, the event was discarded. There may be multiple events produced from a single incoming message, each event is display in its own row. |
+| Outgoing  | The outgoing processed data. If the field is empty, the event was discarded. There may be multiple events produced from a single incoming message, each event is displayed in its own row. |

--- a/docs/note-length.md
+++ b/docs/note-length.md
@@ -10,7 +10,7 @@ A modifier pipe that fixes the note lengths to the given length. If Trigger is s
 | ---------------------- | ---------------------------------- |
 | Bypass                 | Whether processing is enabled.     |
 | Length                 | The length to fix the notes to.    |
-| Gate                   | The percentage amount to expand or shrink the note length parameter. <br/><br/>**0%**: Shortest length,<br/>**100%**: Unchanged length,<br/>**200%**: Double length. |
+| Gate                   | The percentage by which to expand or shrink the note length parameter. <br/><br/>**0%**: Shortest length,<br/>**100%**: Unchanged length,<br/>**200%**: Double length. |
 | Trigger                | Whether to trigger the fixed length note on the Note On or Note Off event. |
 | Sync                   | Whether to sync the length to the tempo. |
 | Decay                  | In case Trigger is set to Note Off, this parameter affects the velocity of the Note On that will get produced when triggered by decaying the velocity of original Note On message. The time set by this parameter is the time it would take to decay the original Note On velocity to 0. |

--- a/docs/note-range-filter.md
+++ b/docs/note-range-filter.md
@@ -7,7 +7,7 @@ A modifier pipe that can discard or keep MIDI Note On and Note Off events in the
 Both ends of the ranges are inclusive.
 
 A single pipe can store up to 9 argument values which are shared for the interval ranges, as well as
-single values. In case of running out of space, a tooltip regarding it will get shown.
+single values. If you run out of space, a tooltip will be shown.
 If you'd like to define more ranges, just put multiple Range Filter pipes in series.
 
 ## Example Ranges
@@ -23,7 +23,7 @@ C-1-B2, C4-B5, C#7
 | Parameter              | Description                    |
 | ---------------------- | ------------------------------ |
 | Bypass                 | Whether processing is enabled. |
-| Drop in range          | Whether to drop messages within any of the ranges. Disabling this would inverse the operation and make it keep messages within the ranges. |
+| Drop in range          | Whether to drop messages within any of the ranges. Disabling this inverts the operation and makes it keep messages within the ranges. |
 | Ranges                 | A list of interval ranges and single values. See above for examples. |
 
 <span class="blokas-web-hide">

--- a/docs/note-repeater.md
+++ b/docs/note-repeater.md
@@ -4,7 +4,7 @@
 
 A modifier pipe that repeats every note held down at the given rate, using the velocity of the last note held down or aftertouch.
 Swing and accent can be applied to the produced notes. The notes produced are quantized to the tempo, so **MIDI Clock messages must
-reach this pipe** for it to be able to do its work. The notes only get produced on quantization grid.
+reach this pipe** for it to be able to do its work. The notes are produced only on the quantization grid.
 
 | Parameter              | Description                        |
 | ---------------------- | ---------------------------------- |

--- a/docs/port-naming.md
+++ b/docs/port-naming.md
@@ -10,7 +10,7 @@ The USB port names as shown by the host OS can be renamed too, see [USB MIDI Por
 It's a good idea to rename the physical ports in the device defaults, and virtual ports in the preset memory, as that keeps presets easier to reuse, and
 changing physical connections and their names easier across all presets in memory.
 
-Here's a table showing what the resulting name of MIDI A input will be, depending on what name's are set in default and preset memories:
+Here's a table showing what the resulting name of MIDI A input will be, depending on what names are set in default and preset memories:
 
 | Default Memory | Preset Memory | Resulting Name |
 | -------------- | ------------- | -------------- |

--- a/docs/sustain.md
+++ b/docs/sustain.md
@@ -3,7 +3,7 @@
 ![sustain](https://blokas.io/images/midihub/pipes/sustain.svg)
 
 A modifier pipe that drops Note Off messages, according to its Mode and Pedal On parameters. Produces all the necessary note off messages once the Pedal is off.
-Chord mode can be used to automatically turn off previous notes once a new chord is being played. Sostenuto holds only the notes that were playing at the time the Pedal was pushed, allowing the performer to play further notes as noraml.
+Chord mode can be used to automatically turn off previous notes once a new chord is being played. Sostenuto holds only the notes that were playing at the time the Pedal was pushed, allowing the performer to play further notes as normal.
 
 | Parameter              | Description                                              |
 | ---------------------- | -------------------------------------------------------- |

--- a/docs/usb-input.md
+++ b/docs/usb-input.md
@@ -2,7 +2,7 @@
 
 ![usb_in](https://blokas.io/images/midihub/pipes/usb_in.svg)
 
-The entry point of USB MIDI data. The data received from PC via the USB cable from matching USB MIDI device will be forwarded as is to the pipe on the right.
+The entry point of USB MIDI data. The data received from the PC via the USB cable from the matching USB MIDI device will be forwarded as is to the pipe on the right.
 
 The 4 USB MIDI ports on the computer map to A, B, C, D letters.
 

--- a/docs/usb-output.md
+++ b/docs/usb-output.md
@@ -2,7 +2,7 @@
 
 ![usb_out](https://blokas.io/images/midihub/pipes/usb_out.svg)
 
-The exit point of MIDI data. The data that reaches this pipe will be sent through the MIDI OUT connector with the matching letter.
+The exit point of MIDI data. The data that reaches this pipe will be sent through the USB port with the matching letter.
 
 The 4 USB MIDI ports on the computer map to A, B, C, D letters.
 

--- a/docs/virtual-input.md
+++ b/docs/virtual-input.md
@@ -2,7 +2,7 @@
 
 ![virt_in](https://blokas.io/images/midihub/pipes/virt_in.svg)
 
-The entry point of Virtual MIDI data. The data that reached the matching letter Virtual Output will appear here in the Virtual Input pipe and will be forwarded as is to the pipe on the right.
+The entry point of Virtual MIDI data. The data that reaches the Virtual Output with the matching letter will appear here in the Virtual Input pipe and will be forwarded as is to the pipe on the right.
 
 | Parameter | Description                    |
 | --------- | ------------------------------ |


### PR DESCRIPTION
## Summary
- fix many grammar issues in README and docs

## Testing
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e93ee269c832da64123157def7fde